### PR TITLE
Hot fix pip install >=

### DIFF
--- a/install.py
+++ b/install.py
@@ -55,7 +55,7 @@ with _REQUIREMENT_PATH.open() as fp:
                     continue
 
                 launch.run_pip(
-                    f"install -U {requirement}",
+                    f"install -U {name}=={version}",
                     f"sd-webui-facefusion requirement: changing {name} version from {installed_version} to {version}",
                 )
                 continue


### PR DESCRIPTION
@linjiX
try with a clean install of webui with no extension then install facefusion
it seems that `install -U insightface>=0.7.3` will install `insightface==0.2.1`
this causing the extension to break